### PR TITLE
Fixed GitHub Actions Workflow and Downgraded C++ Standard from C++20 …

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 ---
 # Project
-Standard: c++20
+Standard: c++17
 ColumnLimit: 120
 
 # Indentation

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 Checks: >
-  -*,
   bugprone-*,
   clang-analyzer-*,
+  cppcoreguidelines-*,
   misc-*,
   modernize-*,
   performance-*,
@@ -18,24 +18,47 @@ Checks: >
   -bugprone-signed-char-misuse,
   -bugprone-string-integer-assignment,
   -bugprone-suspicious-include,
+  -bugprone-switch-missing-default-case,
   -bugprone-unchecked-optional-access,
   -clang-analyzer-nullability.NullablePassedToNonnull,
   -clang-analyzer-optin.cplusplus.VirtualCall,
   -clang-analyzer-optin.osx.*,
   -clang-analyzer-osx.*,
   -clang-analyzer-unix.Malloc,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cppcoreguidelines-avoid-do-while,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-no-malloc,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-prefer-member-initializer,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-rvalue-reference-param-not-moved,
+  -cppcoreguidelines-special-member-functions,
+  -misc-include-cleaner,
   -misc-misplaced-const,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -modernize-avoid-c-arrays,
   -modernize-macro-to-enum,
-  -modernize-return-braced-init-list,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
+  -performance-avoid-endl,
   -performance-inefficient-string-concatenation,
   -performance-no-int-to-ptr,
   -readability-braces-around-statements,
-  -readability-container-contains,
   -readability-convert-member-functions-to-static,
   -readability-else-after-return,
   -readability-function-cognitive-complexity,
@@ -50,6 +73,10 @@ CheckOptions:
   - { key: readability-identifier-naming.FunctionCase,        value: camelBack }
   - { key: readability-identifier-naming.VariableCase,        value: camelBack }
   - { key: readability-identifier-naming.ParameterCase,       value: camelBack }
+  - { key: readability-identifier-naming.MemberCase,          value: camelBack }
+  - { key: readability-identifier-naming.PrivateMemberCase,   value: camelBack }
+  - { key: readability-identifier-naming.ProtectedMemberPrefix, value: m_ }
+  - { key: readability-identifier-naming.PrivateMemberPrefix,   value: m_ }
 HeaderFilterRegex: '.*'
 WarningsAsErrors: '*'
 UseColor: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,110 +5,142 @@ on: [push, pull_request]
 env:
   DISPLAY: ":99" # Display number to use for the X server
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     name: ${{ matrix.platform.name }} ${{ matrix.config.name }} ${{ matrix.type.name }}
     runs-on: ${{ matrix.platform.os }}
 
+    env:
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache # Use ccache to cache C++ compiler output
+
     strategy:
       fail-fast: false
       matrix:
         platform:
-          - { name: Windows MSVC VS2022 x86,    os: windows-2022, flags: -G"Visual Studio 17 2022" -A Win32 }
-          - { name: Windows MSVC VS2022 x64,    os: windows-2022, flags: -G"Visual Studio 17 2022" -A x64 }
-          - { name: Windows ClangCL VS2022 x86, os: windows-2022, flags: -G"Visual Studio 17 2022" -A Win32 -T ClangCL }
-          - { name: Windows ClangCL VS2022 x64, os: windows-2022, flags: -G"Visual Studio 17 2022" -A x64 -T ClangCL }
-          - { name: Windows GCC Ninja,          os: windows-2022, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -GNinja }
-          - { name: Linux GCC Ninja,            os: ubuntu-22.04, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -GNinja }
-          - { name: Linux Clang Ninja,          os: ubuntu-22.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
-          - { name: macOS Clang Ninja,          os: macos-12,     flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
-          - { name: macOS Clang Xcode,          os: macos-12,     flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GXcode }
+          - { name: Windows VS2022 x86,             os: windows-2022, flags: -GNinja }
+          - { name: Windows VS2022 x64,             os: windows-2022, flags: -GNinja }
+          - { name: Windows VS2022 ClangCL MSBuild, os: windows-2022, flags: -T ClangCL }
+          - { name: Windows LLVM/Clang,             os: windows-2022, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
+          - { name: Windows MinGW,                  os: windows-2022, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -GNinja }
+          - { name: Linux GCC,                      os: ubuntu-22.04, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -GNinja }
+          - { name: Linux Clang,                    os: ubuntu-22.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
+          - { name: macOS,                          os: macos-12, flags: -GNinja }
+          - { name: macOS Xcode,                    os: macos-12, flags: -GXcode }
         config:
           - { name: Shared, flags: -DBUILD_SHARED_LIBS=ON }
           - { name: Static, flags: -DBUILD_SHARED_LIBS=OFF }
         type:
           - { name: Release }
           - { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug }
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-
-      - name: Install Windows Dependencies
-        if: runner.os == 'Windows'
-        run: |
-          choco install ninja cmake
-          ninja --version
-          cmake --version
-
-      - name: Install Linux Dependencies
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install ninja-build cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev
-          ninja --version
-          cmake --version
-          gcc --version
-          clang --version
-
-      - name: Install macOS Dependencies
-        if: runner.os == 'macOS'
-        run: |
-          brew install cmake ninja
-          ninja --version
-          cmake --version
-
-      - name: Configure CMake
-        shell: bash
-        run: cmake -S . -B build -DCMAKE_INSTALL_PREFIX=install -DE2D_BUILD_EXAMPLES=ON -DE2D_BUILD_TEST_SUITE=ON ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
-
-      - name: Build Project
-        shell: bash
-        run: cmake --build build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
-
-      - name: Prepare Test
-        shell: bash
-        run: |
-            set -e
-            if [ "${{ runner.os }}" == "Linux" ]; then
-              Xvfb $DISPLAY -screen 0 1920x1080x24 > /dev/null 2>&1 &
-            fi
-            mkdir -p build/bin
-
-      - name: Test
-        shell: bash
-        run: |
-          set -e
-          if [ "${{ runner.os }}" == "Windows" ]; then
-            cmake --build build --target runtests --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
-          else
-            ctest --test-dir build --output-on-failure -C ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
-          fi
-
-      - name: Test Install
-        shell: bash
-        run: |
-          cmake -S test/install -B test/install/build -DE2D_ROOT=./install -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
-          cmake --build test/install/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
-
-  format:
-    name: Formatting with clang-format-${{ matrix.version }}
-    runs-on: ubuntu-22.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        version: [12, 13, 14]
+        include:
+          - platform: { name: Windows MinGW, os: windows-2022 }
+            config: { name: Static Standard Libraries, flags: -GNinja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DBUILD_SHARED_LIBS=OFF -DE2D_USE_STATIC_STD_LIBS=ON }
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Install Dependencies
-        run: sudo apt-get install clang-format-${{ matrix.version }}
+      - name: Set Visual Studio Architecture
+        if: contains(matrix.platform.name, 'Windows VS') && !contains(matrix.platform.name, 'MSBuild')
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ contains(matrix.platform.name, 'x86') && 'x86' || 'x64' }}
+
+      - name: Get CMake and Ninja
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: ${{ runner.os == 'Windows' && '3.25' || '3.22' }}
+          ninjaVersion: latest
+
+      - name: Install Linux Dependencies and Tools
+        if: runner.os == 'Linux'
+        run: |
+          CLANG_VERSION=$(clang++ --version | sed -n 's/.*version \([0-9]\+\)\..*/\1/p')
+          echo "CLANG_VERSION=$CLANG_VERSION" >> $GITHUB_ENV
+          sudo apt-get update && sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev xvfb fluxbox ccache ${{ matrix.platform.name == 'Linux Clang' && 'llvm-$CLANG_VERSION' || '' }}
+
+      - name: Install macOS Tools
+        if: runner.os == 'macOS'
+        run: |
+          brew install ccache || true
+
+      - name: Setup CCache
+        uses: hendrikmuhs/ccache-action@v1.2.10
+        with:
+          verbose: 2
+          key: ${{ matrix.platform.name }}-${{ matrix.config.name }}-${{ matrix.type.name }}
+
+      - name: Cache MinGW
+        if: matrix.platform.name == 'Windows MinGW'
+        id: mingw-cache
+        uses: actions/cache@v3
+        with:
+          path: "C:\\Program Files\\mingw64"
+          key: winlibs-x86_64-posix-seh-gcc-12.2.0-llvm-16.0.0-mingw-w64msvcrt-10.0.0-r5
+
+      - name: Install MinGW
+        if: matrix.platform.name == 'Windows MinGW' && steps.mingw-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -Lo mingw64.zip https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-16.0.0-10.0.0-msvcrt-r5/winlibs-x86_64-posix-seh-gcc-12.2.0-llvm-16.0.0-mingw-w64msvcrt-10.0.0-r5.zip
+          unzip -qq -d "C:\Program Files" mingw64.zip
+
+      - name: Add MinGW to PATH and remove MinGW-supplied CCache
+        if: runner.os == 'Windows'
+        run: |
+          echo "C:\Program Files\mingw64\bin" >> $GITHUB_PATH
+          rm -f "C:\Program Files\mingw64\bin\ccache.exe"
+          echo "Using $(which ccache)"
+          ccache --version
+
+      - name: Configure CMake
+        run: cmake --preset dev -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
+
+      - name: Build
+        run: cmake --build build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
+
+      - name: Prepare Test
+        run: |
+          set -e
+          # Start up Xvfb and fluxbox to host display tests
+          if [ "${{ runner.os }}" == "Linux" ]; then
+            Xvfb $DISPLAY -screen 0 1920x1080x24 &
+            sleep 5
+            fluxbox > /dev/null 2>&1 &
+            sleep 5
+          fi
+          mkdir -p build/bin
+
+      - name: Test
+        if: runner.os == 'Windows'
+        run: cmake --build build --target runtests --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
+
+      - name: Test
+        if: runner.os != 'Windows'
+        run: ctest --test-dir build --output-on-failure -C ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --repeat until-pass:3
+
+      - name: Test Install
+        shell: bash
+        run: |
+          cmake -S test/install -B test/install/build -DE2D_ROOT=build/install -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
+          cmake --build test/install/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
+
+  format:
+    name: Formatting
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
 
       - name: Format Code
-        run: cmake -DCLANG_FORMAT_EXECUTABLE=clang-format-${{ matrix.version }} -P ./cmake/Format.cmake
+        run: cmake -DCLANG_FORMAT_EXECUTABLE=clang-format-14 -P cmake/Format.cmake
 
       - name: Check Formatting
         run: git diff --exit-code
@@ -122,35 +154,36 @@ jobs:
       matrix:
         platform:
           - { name: Windows, os: windows-2022, flags: -GNinja }
-          - { name: Linux,   os: ubuntu-22.04, flags: -GNinja }
-          - { name: macOS,   os: macos-12,     flags: -GNinja }
+          - { name: Linux,   os: ubuntu-22.04 }
+          - { name: macOS,   os: macos-12 }
 
     steps:
-      - name: Checkout Repository
+      - name: Checkout Code
         uses: actions/checkout@v3
+
+      - name: Get CMake and Ninja
+        uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: latest
+          ninjaVersion: latest
 
       - name: Install Windows Dependencies
         if: runner.os == 'Windows'
         run: |
-          choco install ninja cmake
           curl.exe -o run-clang-tidy https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-15.0.7/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install ninja-build cmake libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev
+        run: sudo apt-get update && sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev
 
       - name: Install macOS Dependencies
         if: runner.os == 'macOS'
         run: |
-          brew install cmake ninja llvm || true
+          brew install llvm || true
           echo /usr/local/opt/llvm/bin >> $GITHUB_PATH
 
       - name: Configure
-        shell: bash
-        run: cmake -S . -B build -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DE2D_BUILD_EXAMPLES=TRUE ${{matrix.platform.flags}}
+        run: cmake --preset dev -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ${{matrix.platform.flags}}
 
       - name: Analyze Code
-        shell: bash
         run: cmake --build build --target e2d-tools-tidy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required(VERSION 3.22)
+if(CMAKE_HOST_WIN32)
+    cmake_minimum_required(VERSION 3.24)
+else()
+    cmake_minimum_required(VERSION 3.22)
+endif()
 
 macro(e2d_set_option var default type docstring)
     if(NOT DEFINED ${var})
@@ -9,7 +13,7 @@ endmacro()
 
 e2d_set_option(CMAKE_BUILD_TYPE Release STRING "Choose the type of build (Debug or Release)")
 
-project(E2D VERSION 1.0.0)
+project(E2D VERSION 1.0.0 LANGUAGES C CXX)
 
 include(cmake/Config.cmake)
 
@@ -108,7 +112,7 @@ else()
 
     add_library(E2D ${E2D_SOURCES})
 
-    target_compile_features(E2D PUBLIC cxx_std_20)
+    target_compile_features(E2D PUBLIC cxx_std_17)
 
     e2d_set_stdlib(E2D)
 
@@ -182,7 +186,7 @@ e2d_export_targets()
 
 set(CPACK_PACKAGE_NAME "E2D")
 set(CPACK_PACKAGE_VENDOR "Emil Hörnlund")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "E2D is a 2D game engine written in C++20 using SDL2")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "E2D is a 2D game engine written in C++17 using SDL2")
 set(CPACK_PACKAGE_FILE_NAME "E2D-${PROJECT_VERSION}-${CMAKE_CXX_COMPILER_ID}-${CMAKE_CXX_COMPILER_VERSION}-${CMAKE_BUILD_TYPE}")
 set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,17 @@
+{
+  "version": 3,
+  "configurePresets":[
+    {
+      "name": "dev",
+      "binaryDir": "build",
+      "installDir": "${sourceDir}/build/install",
+      "cacheVariables": {
+        "CMAKE_CXX_EXTENSIONS": "OFF",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "E2D_BUILD_EXAMPLES": "ON",
+        "E2D_BUILD_TEST_SUITE": "ON",
+        "WARNINGS_AS_ERRORS": "ON"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@
 
 ## Overview
 
-E2D is a modern 2D game engine written in C++20 that leverages the SDL2 library. Currently, a work in progress, the project aims to provide developers with a powerful and flexible platform to create cross-platform 2D games with ease. With its comprehensive features, intuitive API, and extensive documentation, E2D aims to empower developers to bring their game ideas to life efficiently and deliver captivating gaming experiences.
+E2D is a modern 2D game engine written in C++17 that leverages the SDL2 library. Currently, a work in progress, the project aims to provide developers with a powerful and flexible platform to create cross-platform 2D games with ease. With its comprehensive features, intuitive API, and extensive documentation, E2D aims to empower developers to bring their game ideas to life efficiently and deliver captivating gaming experiences.
 
 ## Prerequisites
 
 Before building and running the E2D project, ensure you have the following prerequisites:
 
 - **Operating System:** E2D is supported on Linux, Windows, and macOS.
-- **C++20 Compiler:** E2D requires a compiler that supports the C++20 standard. Supported compilers include GNU C++ (GCC), Clang, MinGW, ClangCL and MSVC (Microsoft Visual C++).
+- **C++17 Compiler:** E2D requires a compiler that supports the C++17 standard. Supported compilers include GNU C++ (GCC), Clang, MinGW, ClangCL and MSVC (Microsoft Visual C++).
 - **CMake 3.22 or higher:** E2D uses CMake as the build system. Ensure that you have CMake version 3.22 or higher installed on your system. You can download CMake from the [official CMake website](https://cmake.org/download/).
 - **SDL2 Library:** E2D uses the SDL2 library for graphics and input handling. SDL2 and its extension libraries are already bundled with E2D for Windows and macOS. For Linux, make sure you have SDL2 and the extension libraries (SDL_image and SDL_ttf) installed on your system. Installation instructions for SDL2 can be found in the [official SDL2 documentation](https://www.libsdl.org/download-2.0.php).
 - **Doxygen (optional):** If you plan on generating the documentation, Doxygen is required. You can install Doxygen using the instructions provided for your specific operating system.
@@ -44,7 +44,7 @@ Before building and running the E2D project, ensure you have the following prere
 
 To set up the development environment on Windows, follow these steps:
 
-1. **Compiler:** Install one of the following C++20 compilers:
+1. **Compiler:** Install one of the following C++17 compilers:
    - **Visual Studio:** Download and install Visual Studio 2019 or newer from the [official Microsoft website](https://visualstudio.microsoft.com/downloads/). Make sure to select the C++ development workload during the installation process.
    - **MinGW-w64:** Download and install MinGW-w64 from the [official MinGW-w64 website](http://mingw-w64.org/doku.php). Make sure to select the C++ components during the installation process.
 
@@ -64,7 +64,7 @@ To set up the development environment on Windows, follow these steps:
 
 To set up the development environment on macOS, follow these steps:
 
-1. **Compiler:** macOS comes with Clang installed by default, which supports C++20. No additional installation is required.
+1. **Compiler:** macOS comes with Clang installed by default, which supports C++17. No additional installation is required.
 
 2. **CMake:** Install CMake version 3.22 or higher using Homebrew. Open a terminal and run the following command:
 
@@ -88,7 +88,7 @@ To set up the development environment on macOS, follow these steps:
 
 To set up the development environment on Linux, follow these steps:
 
-1. **Compiler:** Install one of the following C++20 compilers:
+1. **Compiler:** Install one of the following C++17 compilers:
    - **GCC (GNU Compiler Collection):** Open a terminal and run the following command to install GCC:
 
      ```shell

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -40,7 +40,7 @@ macro(e2d_add_library module)
     endif()
     add_library(E2D::${module} ALIAS ${target})
 
-    target_compile_features(${target} PUBLIC cxx_std_20)
+    target_compile_features(${target} PUBLIC cxx_std_17)
 
     set_target_properties(${target} PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/cmake/Tidy.cmake
+++ b/cmake/Tidy.cmake
@@ -28,7 +28,7 @@ if(NOT RUN_CLANG_TIDY)
 endif()
 
 # Run
-execute_process(COMMAND ${Python_EXECUTABLE} ${RUN_CLANG_TIDY} -clang-tidy-binary ${CLANG_TIDY_EXECUTABLE} -p ${PROJECT_BINARY_DIR} RESULTS_VARIABLE EXIT_CODE)
+execute_process(COMMAND ${Python_EXECUTABLE} ${RUN_CLANG_TIDY} -clang-tidy-binary ${CLANG_TIDY_EXECUTABLE} -quiet -p ${PROJECT_BINARY_DIR} RESULTS_VARIABLE EXIT_CODE)
 if(NOT EXIT_CODE STREQUAL 0)
     message(FATAL_ERROR "Analysis failed")
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,11 +6,12 @@ e2d_set_target_warnings(e2d-test-install)
 set(CATCH_CONFIG_FAST_COMPILE ON CACHE BOOL "")
 FetchContent_Declare(Catch2
                      GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-                     GIT_TAG v3.3.2)
+                     GIT_TAG v3.5.0
+                     GIT_SHALLOW ON)
 FetchContent_MakeAvailable(Catch2)
 include(Catch)
 
-target_compile_features(Catch2 PRIVATE cxx_std_20)
+target_compile_features(Catch2 PRIVATE cxx_std_17)
 
 set_target_properties(Catch2 PROPERTIES COMPILE_OPTIONS "" EXPORT_COMPILE_COMMANDS OFF)
 set_target_properties(Catch2WithMain PROPERTIES EXPORT_COMPILE_COMMANDS OFF)


### PR DESCRIPTION
…to C++17

- Downgraded C++ standard from C++20 to C++17 in various CMake configurations to ensure compatibility and stability.
- Updated GitHub Actions workflow configurations to improve build and test processes across different platforms and compilers.
- Modified `.clang-format` and `.clang-tidy` settings to align with the new C++ standard and enhance code quality checks.
- Added and updated various checks in `.clang-tidy` for more comprehensive code analysis.
- Revised CMakeLists and other build scripts to reflect the new C++ standard and workflow changes.
- Updated README to reflect the change in C++ standard used in the project.