### PR TITLE
Refactor Window and Integrate New Renderer Class in E2D Engine

### DIFF
--- a/include/E2D/Engine/Application.hpp
+++ b/include/E2D/Engine/Application.hpp
@@ -35,15 +35,13 @@
 #include <memory>
 #include <string>
 
-struct SDL_Window;
-struct SDL_Renderer;
-
 /**
  * @brief Namespace for E2D
  */
 namespace e2d
 {
-class Window;
+class Renderer; // Forward declaration of Renderer
+class Window;   // Forward declaration of Window
 
 /**
  * @brief Represents the application class.
@@ -100,11 +98,12 @@ protected:
     void setBackgroundColor(const Color& backgroundColor);
 
 private:
-    int                     m_exitCode = 0;     //!< The exit code of the application.
-    bool                    m_running  = false; //!< Flag indicating whether the application is running.
-    const std::string       m_windowTitle;      //!< The title of the window.
-    std::unique_ptr<Window> m_window;           //!< Unique pointer to the window
-    Color                   m_backgroundColor;  //!< The background color of the window
+    int                       m_exitCode = 0;     //!< The exit code of the application.
+    bool                      m_running  = false; //!< Flag indicating whether the application is running.
+    const std::string         m_windowTitle;      //!< The title of the window.
+    std::unique_ptr<Window>   m_window;           //!< Unique pointer to the window
+    std::unique_ptr<Renderer> m_renderer;         //!< Unique pointer to the renderer
+    Color                     m_backgroundColor;  //!< The background color of the window
 
     /**
      * @brief Initializes the SDL library and creates the window and renderer.

--- a/include/E2D/Engine/Renderer.hpp
+++ b/include/E2D/Engine/Renderer.hpp
@@ -1,0 +1,110 @@
+/**
+* Renderer.hpp
+*
+* MIT License
+*
+* Copyright (c) 2023 Emil Hörnlund
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+#ifndef E2D_ENGINE_RENDERER_HPP
+#define E2D_ENGINE_RENDERER_HPP
+
+#include <E2D/Engine/Export.hpp>
+
+#include <E2D/Core/Color.hpp>
+#include <E2D/Core/NonCopyable.hpp>
+
+#include <memory>
+
+/**
+ * @brief Namespace for E2D
+ */
+namespace e2d
+{
+class Window; // Forward declaration of Window
+
+/**
+ * @brief Namespace for E2D internal
+ */
+namespace internal
+{
+class RendererImpl; // Forward declaration of RendererImpl
+}
+
+/**
+ * @class Renderer
+ * @brief Represents a rendering context for drawing graphics.
+ *
+ * This class provides functionalities for rendering graphics onto a linked window.
+ * It offers a simplified interface for drawing operations.
+ */
+class E2D_ENGINE_API Renderer final : NonCopyable
+{
+public:
+    /**
+     * @brief Default constructor for Renderer.
+     *
+     * Constructs a Renderer object.
+     */
+    Renderer();
+
+    /**
+     * @brief Destructor for Renderer.
+     *
+     * Destroys the Renderer object, releasing its resources.
+     */
+    ~Renderer();
+
+    /**
+     * @brief Initializes the renderer with the specified window.
+     *
+     * @param window A reference to the Window object to render to.
+     * @return True if initialization is successful, false otherwise.
+     */
+    bool create(const Window& window);
+
+    /**
+     * @brief Checks if the renderer is created and valid.
+     *
+     * @return True if the renderer is created, false otherwise.
+     */
+    [[maybe_unused]] bool isCreated() const;
+
+    /**
+     * @brief Destroys the renderer, freeing its resources.
+     */
+    void destroy();
+
+    /**
+     * @brief Renders content to the window using the specified color.
+     *
+     * @param drawColor The color to clear the screen with before rendering.
+     */
+    void render(const Color& drawColor) const;
+
+private:
+    std::unique_ptr<internal::RendererImpl> m_rendererImpl; //!< Pointer to the renderer implementation.
+
+}; // class Renderer
+
+} // namespace e2d
+
+#endif //E2D_ENGINE_RENDERER_HPP

--- a/include/E2D/Engine/Window.hpp
+++ b/include/E2D/Engine/Window.hpp
@@ -35,18 +35,6 @@
 #include <memory>
 #include <string>
 
-struct SDL_Window;
-struct SDL_Renderer;
-
-struct SDLDestroyer
-{
-    void operator()(SDL_Window* window) const;
-    void operator()(SDL_Renderer* renderer) const;
-};
-
-using WindowPtr   = std::unique_ptr<SDL_Window, SDLDestroyer>;
-using RendererPtr = std::unique_ptr<SDL_Renderer, SDLDestroyer>;
-
 /**
  * @brief Namespace for E2D
  */
@@ -54,75 +42,72 @@ namespace e2d
 {
 
 /**
- * @brief Represents a window and renderer.
+ * @brief Namespace for E2D internal
+ */
+namespace internal
+{
+class WindowImpl; // Forward declaration of WindowImpl
+}
+
+/**
+ * @class Window
+ * @brief Represents a graphical window.
  *
- * The Window class provides a wrapper around a window and renderer.
- * It manages the lifetime of these resources using smart pointers.
+ * This class provides functionalities to create, manage, and interact with a graphical window.
+ * It abstracts the underlying implementation details and provides a simple interface for window management.
  */
 class E2D_ENGINE_API Window final : NonCopyable
 {
 public:
     /**
-     * @brief Default constructor.
+     * @brief Default constructor for Window.
      *
-     * Constructs a Window object.
+     * Initializes a new Window object.
      */
     Window();
 
     /**
-     * @brief Destructor.
+     * @brief Destructor for Window.
      *
-     * Destroys the Window object.
+     * Cleans up resources used by the Window object.
      */
     ~Window();
 
     /**
-     * @brief Creates a window and renderer.
-     *
-     * Creates a window and renderer with the specified title.
+     * @brief Creates a window with the specified properties.
      *
      * @param title The title of the window.
+     * @param width The width of the window in pixels.
+     * @param height The height of the window in pixels.
      * @return True if the creation was successful, false otherwise.
      */
-    bool create(const std::string& title);
+    bool create(const char* title, int width, int height);
 
     /**
-     * @brief Closes the window and renderer.
+     * @brief Checks if the window is created and valid.
      *
-     * Releases the ownership of the window and renderer resources.
-     * The destruction of the resources is handled automatically by the smart pointers.
+     * @return True if the window is created, false otherwise.
      */
-    void close();
+    [[maybe_unused]] bool isCreated() const;
 
     /**
-     * @brief Clears the renderer with a color.
-     *
-     * Clears the renderer with the specified color.
-     *
-     * @param color The color to clear the renderer with.
+     * @brief Destroys the window, freeing its resources.
      */
-    [[maybe_unused]] bool isOpened() const;
+    void destroy();
 
     /**
-     * @brief Clears the renderer with a color.
+     * @brief Retrieves a handle to the native window.
      *
-     * Clears the renderer with the specified color.
+     * This function is used internally to link the window with other components.
      *
-     * @param color The color to clear the renderer with.
+     * @return A pointer to the native window handle.
      */
-    void clear(const Color& color);
-
-    /**
-     * @brief Presents the renderer.
-     *
-     * Presents the renderer, displaying the rendered content on the window.
-     */
-    void display();
+    void* getNativeWindowHandle() const;
 
 private:
-    WindowPtr   m_window;   //!< Pointer to the SDL window.
-    RendererPtr m_renderer; //!< Pointer to the SDL renderer.
-};
+    std::unique_ptr<internal::WindowImpl> m_windowImpl; //!< Pointer to the window implementation.
+
+}; // class Window
 
 } // namespace e2d
 

--- a/src/E2D/Engine/Application.cpp
+++ b/src/E2D/Engine/Application.cpp
@@ -27,6 +27,7 @@
 #include <E2D/Core/Timer.hpp>
 
 #include <E2D/Engine/Application.hpp>
+#include <E2D/Engine/Renderer.hpp>
 #include <E2D/Engine/Window.hpp>
 
 #include <SDL.h>
@@ -37,6 +38,7 @@
 e2d::Application::Application(std::string windowTitle) :
 m_windowTitle(std::move(windowTitle)),
 m_window(std::make_unique<Window>()),
+m_renderer(std::make_unique<Renderer>()),
 m_backgroundColor(Color::Black)
 {
 }
@@ -108,10 +110,12 @@ bool e2d::Application::initSDL()
         std::cerr << "Failed to initialize SDL: " << SDL_GetError() << std::endl;
         return false;
     }
-
-    if (!this->m_window->create(this->m_windowTitle))
+    if (!this->m_window->create(this->m_windowTitle.c_str(), 800, 600))
     {
-        std::cerr << "Failed to create window: " << SDL_GetError() << std::endl;
+        return false;
+    }
+    if (!this->m_renderer->create(*this->m_window))
+    {
         return false;
     }
     return true;
@@ -119,7 +123,8 @@ bool e2d::Application::initSDL()
 
 void e2d::Application::closeSDL()
 {
-    this->m_window->close();
+    this->m_window->destroy();
+    this->m_renderer->destroy();
     SDL_Quit();
 }
 
@@ -137,11 +142,7 @@ void e2d::Application::handleEvents()
 
 void e2d::Application::render()
 {
-    this->m_window->clear(this->m_backgroundColor);
-
-    //TODO: render other elements here
-
-    this->m_window->display();
+    this->m_renderer->render(this->m_backgroundColor);
 }
 
 const e2d::Color& e2d::Application::getBackgroundColor() const

--- a/src/E2D/Engine/CMakeLists.txt
+++ b/src/E2D/Engine/CMakeLists.txt
@@ -7,8 +7,14 @@ set(SRC
     ${INCROOT}/Application.hpp
     ${SRCROOT}/Application.cpp
     ${INCROOT}/Export.hpp
+    ${INCROOT}/Renderer.hpp
+    ${SRCROOT}/Renderer.cpp
+    ${SRCROOT}/RendererImpl.hpp
+    ${SRCROOT}/RendererImpl.cpp
     ${INCROOT}/Window.hpp
     ${SRCROOT}/Window.cpp
+    ${SRCROOT}/WindowImpl.hpp
+    ${SRCROOT}/WindowImpl.cpp
 )
 
 e2d_add_library(Engine SOURCES ${SRC})

--- a/src/E2D/Engine/Renderer.cpp
+++ b/src/E2D/Engine/Renderer.cpp
@@ -1,0 +1,55 @@
+/**
+* Renderer.cpp
+*
+* MIT License
+*
+* Copyright (c) 2023 Emil Hörnlund
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+#include <E2D/Engine/Renderer.hpp>
+#include <E2D/Engine/RendererImpl.hpp>
+#include <E2D/Engine/Window.hpp>
+
+e2d::Renderer::Renderer() : m_rendererImpl(std::make_unique<internal::RendererImpl>())
+{
+}
+
+e2d::Renderer::~Renderer() = default;
+
+bool e2d::Renderer::create(const e2d::Window& window)
+{
+    return this->m_rendererImpl->create(static_cast<SDL_Window*>(window.getNativeWindowHandle()));
+}
+
+bool e2d::Renderer::isCreated() const
+{
+    return this->m_rendererImpl->isCreated();
+}
+
+void e2d::Renderer::destroy()
+{
+    this->m_rendererImpl->destroy();
+}
+
+void e2d::Renderer::render(const e2d::Color& drawColor) const
+{
+    this->m_rendererImpl->render(drawColor);
+}

--- a/src/E2D/Engine/RendererImpl.cpp
+++ b/src/E2D/Engine/RendererImpl.cpp
@@ -1,0 +1,76 @@
+/**
+* RendererImpl.cpp
+*
+* MIT License
+*
+* Copyright (c) 2023 Emil Hörnlund
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+#include <E2D/Engine/RendererImpl.hpp>
+
+#include <SDL.h>
+
+#include <iostream>
+
+e2d::internal::RendererImpl::RendererImpl() = default;
+
+e2d::internal::RendererImpl::~RendererImpl()
+{
+    this->destroy();
+}
+
+bool e2d::internal::RendererImpl::create(SDL_Window* window)
+{
+    this->m_renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+    if (this->m_renderer == nullptr)
+    {
+        std::cerr << "Failed to create renderer: " << SDL_GetError() << '\n';
+        return false;
+    }
+    return true;
+}
+
+bool e2d::internal::RendererImpl::isCreated() const
+{
+    return this->m_renderer != nullptr;
+}
+
+
+void e2d::internal::RendererImpl::destroy()
+{
+    if (this->m_renderer)
+    {
+        SDL_DestroyRenderer(this->m_renderer);
+        this->m_renderer = nullptr;
+    }
+}
+
+SDL_Renderer* e2d::internal::RendererImpl::getRenderer() const
+{
+    return this->m_renderer;
+}
+
+void e2d::internal::RendererImpl::render(const e2d::Color& drawColor) const
+{
+    SDL_SetRenderDrawColor(this->m_renderer, drawColor.r, drawColor.g, drawColor.b, drawColor.a);
+    SDL_RenderClear(this->m_renderer);
+    SDL_RenderPresent(this->m_renderer);
+}

--- a/src/E2D/Engine/RendererImpl.hpp
+++ b/src/E2D/Engine/RendererImpl.hpp
@@ -1,0 +1,111 @@
+/**
+* RendererImpl.hpp
+*
+* MIT License
+*
+* Copyright (c) 2023 Emil Hörnlund
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+#ifndef E2D_ENGINE_RENDERER_IMPL_HPP
+#define E2D_ENGINE_RENDERER_IMPL_HPP
+
+#include <E2D/Engine/Export.hpp>
+
+#include <E2D/Core/Color.hpp>
+#include <E2D/Core/NonCopyable.hpp>
+
+#include <memory>
+
+struct SDL_Renderer; // Forward declaration of SDL_Renderer
+struct SDL_Window;   // Forward declaration of SDL_Window
+
+/**
+ * @brief Namespace for E2D internal
+ */
+namespace e2d::internal
+{
+
+/**
+ * @class RendererImpl
+ * @brief Internal implementation class for Renderer.
+ *
+ * This class is responsible for the low-level details of rendering operations.
+ * It interfaces directly with the graphics hardware through the underlying rendering system.
+ */
+class E2D_ENGINE_API RendererImpl final : NonCopyable
+{
+public:
+    /**
+     * @brief Default constructor for RendererImpl.
+     *
+     * Initializes a new instance of the RendererImpl class.
+     */
+    RendererImpl();
+
+    /**
+     * @brief Destructor for RendererImpl.
+     *
+     * Cleans up resources used by the RendererImpl object.
+     */
+    ~RendererImpl();
+
+    /**
+     * @brief Initializes the renderer with the specified window.
+     *
+     * @param window A pointer to an SDL_Window object representing the window to render to.
+     * @return True if the renderer is successfully created, false otherwise.
+     */
+    bool create(SDL_Window* window);
+
+    /**
+     * @brief Checks if the renderer is created and valid.
+     *
+     * @return True if the renderer is created, false otherwise.
+     */
+    [[maybe_unused]] bool isCreated() const;
+
+    /**
+     * @brief Destroys the renderer, freeing associated resources.
+     */
+    void destroy();
+
+    /**
+     * @brief Retrieves the native renderer object.
+     *
+     * @return A pointer to the underlying SDL_Renderer object.
+     */
+    SDL_Renderer* getRenderer() const;
+
+    /**
+     * @brief Executes the rendering process using a specified color.
+     *
+     * @param drawColor The color used for clearing the screen before rendering.
+     */
+    void render(const Color& drawColor) const;
+
+private:
+    SDL_Renderer* m_renderer{nullptr}; //!< Pointer to the SDL_Renderer object.
+
+}; // class RendererImpl
+
+} // namespace e2d::internal
+
+#endif //E2D_ENGINE_RENDERER_IMPL_HPP

--- a/src/E2D/Engine/Window.cpp
+++ b/src/E2D/Engine/Window.cpp
@@ -25,64 +25,30 @@
  */
 
 #include <E2D/Engine/Window.hpp>
+#include <E2D/Engine/WindowImpl.hpp>
 
-#include <SDL.h>
-
-#include <iostream>
-
-e2d::Window::Window() = default;
+e2d::Window::Window() : m_windowImpl(std::make_unique<internal::WindowImpl>())
+{
+}
 
 e2d::Window::~Window() = default;
 
-bool e2d::Window::create(const std::string& title)
+bool e2d::Window::create(const char* title, int width, int height)
 {
-    this->m_window = WindowPtr(
-        SDL_CreateWindow(title.c_str(), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 800, 600, SDL_WINDOW_SHOWN));
-
-    if (this->m_window == nullptr)
-    {
-        std::cerr << "Failed to create window: " << SDL_GetError() << std::endl;
-        return false;
-    }
-
-    this->m_renderer = RendererPtr(SDL_CreateRenderer(this->m_window.get(), -1, SDL_RENDERER_ACCELERATED));
-    if (this->m_renderer == nullptr)
-    {
-        std::cerr << "Failed to create renderer: " << SDL_GetError() << std::endl;
-        return false;
-    }
-
-    return true;
+    return this->m_windowImpl->create(title, width, height);
 }
 
-void e2d::Window::close()
+bool e2d::Window::isCreated() const
 {
-    this->m_renderer.reset();
-    this->m_window.reset();
+    return this->m_windowImpl->isCreated();
 }
 
-void e2d::Window::display()
+void e2d::Window::destroy()
 {
-    SDL_RenderPresent(this->m_renderer.get());
+    this->m_windowImpl->destroy();
 }
 
-void e2d::Window::clear(const e2d::Color& color)
+void* e2d::Window::getNativeWindowHandle() const
 {
-    SDL_SetRenderDrawColor(this->m_renderer.get(), color.r, color.g, color.b, color.a);
-    SDL_RenderClear(this->m_renderer.get());
-}
-
-[[maybe_unused]] bool e2d::Window::isOpened() const
-{
-    return (this->m_window != nullptr);
-}
-
-void SDLDestroyer::operator()(SDL_Window* window) const
-{
-    SDL_DestroyWindow(window);
-}
-
-void SDLDestroyer::operator()(SDL_Renderer* renderer) const
-{
-    SDL_DestroyRenderer(renderer);
+    return this->m_windowImpl->getWindow();
 }

--- a/src/E2D/Engine/WindowImpl.cpp
+++ b/src/E2D/Engine/WindowImpl.cpp
@@ -1,0 +1,68 @@
+/**
+* WindowImpl.cpp
+*
+* MIT License
+*
+* Copyright (c) 2023 Emil Hörnlund
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+#include <E2D/Engine/WindowImpl.hpp>
+
+#include <SDL.h>
+
+#include <iostream>
+
+e2d::internal::WindowImpl::WindowImpl() = default;
+
+e2d::internal::WindowImpl::~WindowImpl()
+{
+    this->destroy();
+}
+
+bool e2d::internal::WindowImpl::create(const char* title, int width, int height)
+{
+    this->m_window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height, SDL_WINDOW_SHOWN);
+    if (this->m_window == nullptr)
+    {
+        std::cerr << "Failed to create window: " << SDL_GetError() << '\n';
+        return false;
+    }
+    return true;
+}
+
+bool e2d::internal::WindowImpl::isCreated() const
+{
+    return this->m_window != nullptr;
+}
+
+void e2d::internal::WindowImpl::destroy()
+{
+    if (this->m_window)
+    {
+        SDL_DestroyWindow(this->m_window);
+        this->m_window = nullptr;
+    }
+}
+
+SDL_Window* e2d::internal::WindowImpl::getWindow() const
+{
+    return this->m_window;
+}

--- a/src/E2D/Engine/WindowImpl.hpp
+++ b/src/E2D/Engine/WindowImpl.hpp
@@ -1,0 +1,104 @@
+/**
+* WindowImpl.hpp
+*
+* MIT License
+*
+* Copyright (c) 2023 Emil Hörnlund
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+#ifndef E2D_ENGINE_WINDOW_IMPL_HPP
+#define E2D_ENGINE_WINDOW_IMPL_HPP
+
+#include <E2D/Engine/Export.hpp>
+
+#include <E2D/Core/NonCopyable.hpp>
+
+#include <memory>
+
+struct SDL_Window; // Forward declaration of SDL_Window
+
+/**
+ * @brief Namespace for E2D internal
+ */
+namespace e2d::internal
+{
+
+/**
+ * @class WindowImpl
+ * @brief Internal implementation class for Window.
+ *
+ * This class manages the low-level details of window creation, management, and destruction.
+ * It interfaces directly with the underlying windowing system.
+ */
+class E2D_ENGINE_API WindowImpl final : NonCopyable
+{
+public:
+    /**
+     * @brief Default constructor for WindowImpl.
+     *
+     * Initializes a new instance of the WindowImpl class.
+     */
+    WindowImpl();
+
+    /**
+     * @brief Destructor for WindowImpl.
+     *
+     * Cleans up resources used by the WindowImpl object.
+     */
+    ~WindowImpl();
+
+    /**
+     * @brief Creates a window with specified properties.
+     *
+     * @param title The title of the window.
+     * @param width The width of the window in pixels.
+     * @param height The height of the window in pixels.
+     * @return True if the window is successfully created, false otherwise.
+     */
+    bool create(const char* title, int width, int height);
+
+    /**
+     * @brief Checks if the window is currently created and valid.
+     *
+     * @return True if the window is created, false otherwise.
+     */
+    [[maybe_unused]] bool isCreated() const;
+
+    /**
+     * @brief Destroys the window, freeing associated resources.
+     */
+    void destroy();
+
+    /**
+     * @brief Retrieves the native window object.
+     *
+     * @return A pointer to the underlying SDL_Window object.
+     */
+    SDL_Window* getWindow() const;
+
+private:
+    SDL_Window* m_window{nullptr}; //!< Pointer to the SDL_Window object.
+
+}; // class WindowImpl
+
+} // namespace e2d::internal
+
+#endif //E2D_ENGINE_WINDOW_IMPL_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ e2d_add_test(e2d-test-core "${CORE_SRC}" E2D::Core)
 # E2D Engine Library Tests
 set(ENGINE_SRC
     Engine/Application.test.cpp
+    Engine/Renderer.test.cpp
     Engine/Window.test.cpp
 )
 e2d_add_test(e2d-test-engine "${ENGINE_SRC}" E2D::Engine)

--- a/test/Engine/Renderer.test.cpp
+++ b/test/Engine/Renderer.test.cpp
@@ -24,24 +24,28 @@
  * THE SOFTWARE.
  */
 
+#include <E2D/Engine/Renderer.hpp>
 #include <E2D/Engine/Window.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
-TEST_CASE("Window Creation and Destruction", "[Window]")
+TEST_CASE("Renderer Creation and Destruction", "[Window]")
 {
     e2d::Window window;
+    window.create("Test Window", 800, 600);
 
-    SECTION("Create Window")
+    e2d::Renderer renderer;
+
+    SECTION("Create Renderer")
     {
-        REQUIRE(window.create("Test Window", 800, 600) == true);
-        REQUIRE(window.isCreated() == true);
+        REQUIRE(renderer.create(window) == true);
+        REQUIRE(renderer.isCreated() == true);
     }
 
-    SECTION("Destroy Window")
+    SECTION("Destroy Renderer")
     {
-        REQUIRE(window.create("Test Window", 800, 600) == true);
-        window.destroy();
-        REQUIRE(window.isCreated() == false);
+        REQUIRE(renderer.create(window) == true);
+        renderer.destroy();
+        REQUIRE(renderer.isCreated() == false);
     }
 }


### PR DESCRIPTION
- Introduced a new Renderer class for handling rendering operations.
- Removed direct SDL_Window and SDL_Renderer dependencies from the Window class.
- Window class now interacts with the Renderer class, encapsulating the rendering logic.
- Updated Application class to accommodate changes in Window and integrate Renderer.
- Added necessary Renderer implementation files (Renderer.hpp/cpp, RendererImpl.hpp/cpp).
- Adjusted Window implementation to align with the new Renderer integration.
- Removed SDL_Window and SDL_Renderer structures from Window.hpp.
- Updated CMakeLists.txt to include new Renderer source files.
- Added unit tests for the Renderer class.
- Ensured compliance with the MIT License in new files.

This refactor enhances the modularity and clarity of the E2D engine's architecture, isolating the rendering logic in its dedicated class while simplifying the Window class's responsibilities.