### PR TITLE
Implement Renderable Interface and Integrate RenderQueue

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -170,6 +170,10 @@ function(e2d_add_test target SOURCES DEPENDS)
 
     set_target_properties(${target} PROPERTIES FOLDER "Tests")
 
+    target_include_directories(${target}
+            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            PRIVATE ${PROJECT_SOURCE_DIR}/src)
+
     target_link_libraries(${target} PRIVATE ${DEPENDS} Catch2::Catch2WithMain)
 
     e2d_set_target_warnings(${target})

--- a/include/E2D/Engine.hpp
+++ b/include/E2D/Engine.hpp
@@ -31,7 +31,9 @@
 
 #include <E2D/Engine/Application.hpp>
 #include <E2D/Engine/GraphicsSystem.hpp>
+#include <E2D/Engine/Renderable.hpp>
 #include <E2D/Engine/Renderer.hpp>
+#include <E2D/Engine/Sprite.hpp>
 #include <E2D/Engine/System.hpp>
 #include <E2D/Engine/SystemManager.hpp>
 #include <E2D/Engine/TextRenderingSystem.hpp>

--- a/include/E2D/Engine/Application.hpp
+++ b/include/E2D/Engine/Application.hpp
@@ -110,11 +110,6 @@ private:
      */
     void handleEvents();
 
-    /**
-     * @brief Renders the application content.
-     */
-    void render();
-
 }; //Application class
 
 } // namespace e2d

--- a/include/E2D/Engine/Renderable.hpp
+++ b/include/E2D/Engine/Renderable.hpp
@@ -1,0 +1,84 @@
+/**
+* Renderable.hpp
+*
+* MIT License
+*
+* Copyright (c) 2023 Emil Hörnlund
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+#ifndef E2D_ENGINE_RENDERABLE_HPP
+#define E2D_ENGINE_RENDERABLE_HPP
+
+#include <E2D/Engine/Export.hpp>
+
+#include <E2D/Core/NonCopyable.hpp>
+
+/**
+ * @brief Namespace for E2D
+ */
+namespace e2d
+{
+class Renderer; // Forward declaration of Renderer
+
+/**
+ * @class Renderable
+ * @brief Abstract base class for renderable objects.
+ *
+ * This class provides an interface for all objects that can be rendered
+ * using a Renderer. It declares a pure virtual render method that must
+ * be implemented by all derived classes.
+ */
+class E2D_ENGINE_API Renderable : NonCopyable
+{
+public:
+    /**
+     * @brief Virtual destructor for Renderable.
+     *
+     * Ensures proper destruction of derived classes.
+     */
+    virtual ~Renderable() = default;
+
+    /**
+     * @brief Gets the render priority of the object.
+     *
+     * This pure virtual function must be implemented by derived classes.
+     * It should return a value indicating the rendering order of the object.
+     * Objects with higher priority values should be rendered later (on top).
+     *
+     * @return int The render priority of the object.
+     */
+    virtual int getRenderPriority() const = 0;
+
+    /**
+     * @brief Renders the object using the given renderer.
+     *
+     * This is a pure virtual function that must be implemented by
+     * all derived classes to define how they should be rendered.
+     *
+     * @param renderer The renderer to use for rendering.
+     */
+    virtual void render(const Renderer& renderer) const = 0;
+
+}; // class Renderable
+
+} // namespace e2d
+
+#endif //E2D_ENGINE_RENDERABLE_HPP

--- a/include/E2D/Engine/Renderer.hpp
+++ b/include/E2D/Engine/Renderer.hpp
@@ -39,7 +39,8 @@
  */
 namespace e2d
 {
-class Window; // Forward declaration of Window
+class Renderable; // Forward declaration of Renderable
+class Window;     // Forward declaration of Window
 
 /**
  * @brief Namespace for E2D internal
@@ -47,14 +48,18 @@ class Window; // Forward declaration of Window
 namespace internal
 {
 class RendererImpl; // Forward declaration of RendererImpl
-}
+class RenderQueue;  // Forward declaration of RenderQueue
+} // namespace internal
 
 /**
  * @class Renderer
- * @brief Represents a rendering context for drawing graphics.
+ * @brief Handles the rendering process for graphical objects.
  *
- * This class provides functionalities for rendering graphics onto a linked window.
- * It offers a simplified interface for drawing operations.
+ * The Renderer class is responsible for managing and executing the rendering process
+ * of Renderable objects within the E2D Engine. It maintains a render queue to sort
+ * and render objects based on their render priority. The Renderer class provides
+ * functions for adding Renderable objects to the queue and for performing the actual
+ * rendering process to display the content on the screen.
  */
 class E2D_ENGINE_API Renderer final : NonCopyable
 {
@@ -94,6 +99,17 @@ public:
     void destroy();
 
     /**
+     * @brief Adds a Renderable object to the render queue.
+     *
+     * This method adds the given Renderable object to the render queue. The object
+     * will be rendered in order based on its render priority when the render
+     * method is called.
+     *
+     * @param renderable Pointer to the Renderable object to be added to the queue.
+     */
+    void draw(const Renderable* renderable);
+
+    /**
      * @brief Renders content to the window using the specified color.
      *
      * @param drawColor The color to clear the screen with before rendering.
@@ -111,6 +127,7 @@ public:
 
 private:
     std::unique_ptr<internal::RendererImpl> m_rendererImpl; //!< Pointer to the renderer implementation.
+    std::unique_ptr<internal::RenderQueue>  m_renderQueue;  //!< Pointer to the render queue.
 
 }; // class Renderer
 

--- a/include/E2D/Engine/Sprite.hpp
+++ b/include/E2D/Engine/Sprite.hpp
@@ -1,0 +1,119 @@
+/**
+* Sprite.hpp
+*
+* MIT License
+*
+* Copyright (c) 2023 Emil Hörnlund
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+#ifndef E2D_ENGINE_SPRITE_HPP
+#define E2D_ENGINE_SPRITE_HPP
+
+#include <E2D/Engine/Export.hpp>
+
+#include <E2D/Core/NonCopyable.hpp>
+
+#include <E2D/Engine/Renderable.hpp>
+
+#include <memory>
+
+/**
+ * @brief Namespace for E2D
+ */
+namespace e2d
+{
+class Renderer; // Forward declaration of Renderer
+class Texture;  // Forward declaration of Texture
+
+/**
+ * @class Sprite
+ * @brief Represents a 2D graphical object.
+ *
+ * The Sprite class is a concrete implementation of the Renderable interface.
+ * It represents a 2D graphical object that can be rendered on the screen.
+ * Each Sprite object maintains a texture that defines its visual appearance.
+ * Sprites have render priorities that determine their rendering order.
+ */
+class E2D_ENGINE_API Sprite final : public Renderable
+{
+public:
+    /**
+     * @brief Default constructor for Sprite.
+     *
+     * Constructs a Sprite object.
+     */
+    Sprite();
+
+    /**
+     * @brief Destructor for Sprite.
+     *
+     * Destroys the Sprite object, releasing its resources.
+     */
+    ~Sprite() final;
+
+    /**
+     * @brief Retrieves the texture of the sprite.
+     *
+     * Returns a shared pointer to the Texture object associated with the sprite.
+     * This texture defines the visual appearance of the sprite.
+     *
+     * @return std::shared_ptr<Texture> Shared pointer to the sprite's texture.
+     */
+    std::shared_ptr<Texture> getTexture() const;
+
+    /**
+     * @brief Sets the texture of the sprite.
+     *
+     * Assigns a new texture to the sprite. The texture defines the sprite's
+     * visual appearance.
+     *
+     * @param texture Shared pointer to the new Texture object.
+     */
+    void setTexture(const std::shared_ptr<Texture>& texture);
+
+    /**
+     * @brief Retrieves the render priority of the sprite.
+     *
+     * Returns an integer representing the render priority of the sprite.
+     * Sprites with higher priority values are rendered later (on top of others).
+     *
+     * @return int The render priority of the sprite.
+     */
+    int getRenderPriority() const final;
+
+    /**
+     * @brief Renders the sprite using the provided renderer.
+     *
+     * Renders the sprite using the given Renderer object. The method
+     * uses the Renderer to draw the sprite's texture on the screen.
+     *
+     * @param renderer The Renderer object used for rendering the sprite.
+     */
+    void render(const Renderer& renderer) const final;
+
+private:
+    std::shared_ptr<Texture> m_texture; //!< Pointer to the sprite's texture.
+
+}; // class Sprite
+
+} // namespace e2d
+
+#endif //E2D_ENGINE_SPRITE_HPP

--- a/src/E2D/Engine/Application.cpp
+++ b/src/E2D/Engine/Application.cpp
@@ -91,7 +91,9 @@ int e2d::Application::run()
             remainder = 0.0;
         }
 
-        this->render();
+        // TODO: Draw all objects
+
+        this->m_renderer->render(this->m_backgroundColor);
 
         elapsedTime += elapsedFrameTimeAsSeconds;
         if (elapsedTime >= 1.0)
@@ -129,11 +131,6 @@ void e2d::Application::handleEvents()
             this->quit();
         }
     }
-}
-
-void e2d::Application::render()
-{
-    this->m_renderer->render(this->m_backgroundColor);
 }
 
 const e2d::Color& e2d::Application::getBackgroundColor() const

--- a/src/E2D/Engine/CMakeLists.txt
+++ b/src/E2D/Engine/CMakeLists.txt
@@ -9,10 +9,15 @@ set(SRC
     ${INCROOT}/Export.hpp
     ${INCROOT}/GraphicsSystem.hpp
     ${SRCROOT}/GraphicsSystem.cpp
+    ${INCROOT}/Renderable.hpp
     ${INCROOT}/Renderer.hpp
     ${SRCROOT}/Renderer.cpp
     ${SRCROOT}/RendererImpl.hpp
     ${SRCROOT}/RendererImpl.cpp
+    ${SRCROOT}/RenderQueue.hpp
+    ${SRCROOT}/RenderQueue.cpp
+    ${INCROOT}/Sprite.hpp
+    ${SRCROOT}/Sprite.cpp
     ${INCROOT}/System.hpp
     ${INCROOT}/SystemManager.hpp
     ${SRCROOT}/SystemManager.cpp

--- a/src/E2D/Engine/RenderQueue.cpp
+++ b/src/E2D/Engine/RenderQueue.cpp
@@ -1,0 +1,52 @@
+/**
+* RenderQueue.cpp
+*
+* MIT License
+*
+* Copyright (c) 2023 Emil Hörnlund
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+#include <E2D/Engine/RenderQueue.hpp>
+
+e2d::internal::RenderQueue::RenderQueue() = default;
+
+e2d::internal::RenderQueue::~RenderQueue() = default;
+
+void e2d::internal::RenderQueue::push(const e2d::Renderable* renderable)
+{
+    this->m_queue.push(renderable);
+}
+
+const e2d::Renderable* e2d::internal::RenderQueue::pop()
+{
+    if (!this->m_queue.empty())
+    {
+        const Renderable* topElement = this->m_queue.top();
+        this->m_queue.pop();
+        return topElement;
+    }
+    return nullptr;
+}
+
+bool e2d::internal::RenderQueue::isEmpty() const
+{
+    return this->m_queue.empty();
+}

--- a/src/E2D/Engine/RenderQueue.hpp
+++ b/src/E2D/Engine/RenderQueue.hpp
@@ -1,0 +1,132 @@
+/**
+* RenderQueue.hpp
+*
+* MIT License
+*
+* Copyright (c) 2023 Emil Hörnlund
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+#ifndef E2D_ENGINE_RENDER_QUEUE_HPP
+#define E2D_ENGINE_RENDER_QUEUE_HPP
+
+#include <E2D/Engine/Export.hpp>
+
+#include <E2D/Core/NonCopyable.hpp>
+
+#include <E2D/Engine/Renderable.hpp>
+
+#include <functional>
+#include <queue>
+
+/**
+ * @brief Namespace for E2D
+ */
+namespace e2d::internal
+{
+
+/**
+ * @class RenderQueue
+ * @brief Manages a priority queue of Renderable objects.
+ *
+ * RenderQueue is a utility class that manages a queue of Renderable objects,
+ * sorting them based on their render priority. This ensures that objects
+ * are rendered in the correct order. The class uses a priority queue where
+ * objects with higher render priorities are rendered later.
+ */
+class E2D_ENGINE_API RenderQueue final : NonCopyable
+{
+public:
+    /**
+     * @brief Default constructor for RenderQueue.
+     *
+     * Constructs a RenderQueue object.
+     */
+    RenderQueue();
+
+    /**
+     * @brief Destructor for RenderQueue.
+     *
+     * Destroys the RenderQueue object, releasing its resources.
+     */
+    ~RenderQueue();
+
+    /**
+     * @brief Adds a Renderable object to the queue.
+     *
+     * Inserts the provided Renderable object into the queue. The object
+     * is ordered within the queue based on its render priority.
+     *
+     * @param renderable Pointer to the Renderable object to be added to the queue.
+     */
+    void push(const Renderable* renderable);
+
+    /**
+     * @brief Removes and returns the Renderable object with the highest priority.
+     *
+     * Pops the Renderable object with the highest render priority from the queue
+     * and returns it. If the queue is empty, returns nullptr.
+     *
+     * @return const Renderable* Pointer to the Renderable object with the highest priority,
+     *         or nullptr if the queue is empty.
+     */
+    const Renderable* pop();
+
+    /**
+     * @brief Checks if the queue is empty.
+     *
+     * @return bool True if the queue is empty, false otherwise.
+     */
+    bool isEmpty() const;
+
+private:
+    /**
+     * @struct RenderableCompare
+     * @brief Function for comparing two Renderable objects based on render priority.
+     *
+     * This struct is used to define the comparison criteria for ordering
+     * Renderable objects within the RenderQueue. It compares two Renderable
+     * objects based on their render priority.
+     */
+    struct RenderableCompare
+    {
+        /**
+         * @brief Compares two Renderable objects.
+         *
+         * Determines the order of the Renderable objects in the queue
+         * based on their render priority.
+         *
+         * @param lhs Pointer to the first Renderable object.
+         * @param rhs Pointer to the second Renderable object.
+         * @return bool True if the first object has higher render priority than the second, false otherwise.
+         */
+        bool operator()(const Renderable* lhs, const Renderable* rhs) const
+        {
+            return lhs->getRenderPriority() > rhs->getRenderPriority();
+        }
+    };
+
+    std::priority_queue<const Renderable*, std::vector<const Renderable*>, RenderableCompare> m_queue; //!< Priority queue of Renderable objects.
+
+}; // class RenderQueue
+
+} // namespace e2d::internal
+
+#endif //E2D_ENGINE_RENDER_QUEUE_HPP

--- a/src/E2D/Engine/Renderer.cpp
+++ b/src/E2D/Engine/Renderer.cpp
@@ -24,11 +24,15 @@
 * THE SOFTWARE.
 */
 
+#include <E2D/Engine/Renderable.hpp>
 #include <E2D/Engine/Renderer.hpp>
 #include <E2D/Engine/RendererImpl.hpp>
+#include <E2D/Engine/RenderQueue.hpp>
 #include <E2D/Engine/Window.hpp>
 
-e2d::Renderer::Renderer() : m_rendererImpl(std::make_unique<internal::RendererImpl>())
+e2d::Renderer::Renderer() :
+m_rendererImpl(std::make_unique<internal::RendererImpl>()),
+m_renderQueue(std::make_unique<internal::RenderQueue>())
 {
 }
 
@@ -49,9 +53,25 @@ void e2d::Renderer::destroy()
     this->m_rendererImpl->destroy();
 }
 
+void e2d::Renderer::draw(const e2d::Renderable* renderable)
+{
+    this->m_renderQueue->push(renderable);
+}
+
 void e2d::Renderer::render(const e2d::Color& drawColor) const
 {
-    this->m_rendererImpl->render(drawColor);
+    this->m_rendererImpl->clear(drawColor);
+
+    while (!this->m_renderQueue->isEmpty())
+    {
+        const Renderable* renderable = this->m_renderQueue->pop();
+        if (renderable)
+        {
+            renderable->render(*this);
+        }
+    }
+
+    this->m_rendererImpl->display();
 }
 
 void* e2d::Renderer::getNativeRendererHandle() const

--- a/src/E2D/Engine/RendererImpl.hpp
+++ b/src/E2D/Engine/RendererImpl.hpp
@@ -95,11 +95,25 @@ public:
     SDL_Renderer* getRenderer() const;
 
     /**
-     * @brief Executes the rendering process using a specified color.
+     * @brief Clears the screen with a specified color.
+     *
+     * This method sets the renderer's drawing color to the specified Color object,
+     * and then clears the rendering target with this color. It is typically used
+     * to reset the screen before drawing new graphics in each frame of a rendering loop.
      *
      * @param drawColor The color used for clearing the screen before rendering.
      */
-    void render(const Color& drawColor) const;
+    void clear(const Color& drawColor);
+
+    /**
+     * @brief Presents the rendered content on the screen.
+     *
+     * This method updates the screen with any rendering performed since the last call.
+     * It should be called after all rendering operations are completed for the current frame,
+     * effectively displaying the rendered content on the screen. This is typically the last
+     * function called in a rendering loop.
+     */
+    void display();
 
 private:
     SDL_Renderer* m_renderer{nullptr}; //!< Pointer to the SDL_Renderer object.

--- a/src/E2D/Engine/Sprite.cpp
+++ b/src/E2D/Engine/Sprite.cpp
@@ -1,5 +1,5 @@
 /**
-* RendererImpl.cpp
+* Sprite.cpp
 *
 * MIT License
 *
@@ -24,57 +24,38 @@
 * THE SOFTWARE.
 */
 
-#include <E2D/Engine/RendererImpl.hpp>
+#include <E2D/Engine/Renderer.hpp>
+#include <E2D/Engine/Sprite.hpp>
+#include <E2D/Engine/Texture.hpp>
 
 #include <SDL.h>
 
-#include <iostream>
+e2d::Sprite::Sprite() = default;
 
-e2d::internal::RendererImpl::RendererImpl() = default;
+e2d::Sprite::~Sprite() = default;
 
-e2d::internal::RendererImpl::~RendererImpl()
+std::shared_ptr<e2d::Texture> e2d::Sprite::getTexture() const
 {
-    this->destroy();
+    return this->m_texture;
 }
 
-bool e2d::internal::RendererImpl::create(SDL_Window* window)
+void e2d::Sprite::setTexture(const std::shared_ptr<Texture>& texture)
 {
-    this->m_renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
-    if (this->m_renderer == nullptr)
+    this->m_texture = texture;
+}
+
+int e2d::Sprite::getRenderPriority() const
+{
+    return 0;
+}
+
+void e2d::Sprite::render(const e2d::Renderer& renderer) const
+{
+    if (this->m_texture)
     {
-        std::cerr << "Failed to create renderer: " << SDL_GetError() << '\n';
-        return false;
+        SDL_RenderCopy(static_cast<SDL_Renderer*>(renderer.getNativeRendererHandle()),
+                       static_cast<SDL_Texture*>(this->m_texture->getNativeTextureHandle()),
+                       nullptr,
+                       nullptr);
     }
-    return true;
-}
-
-bool e2d::internal::RendererImpl::isCreated() const
-{
-    return this->m_renderer != nullptr;
-}
-
-
-void e2d::internal::RendererImpl::destroy()
-{
-    if (this->m_renderer)
-    {
-        SDL_DestroyRenderer(this->m_renderer);
-        this->m_renderer = nullptr;
-    }
-}
-
-SDL_Renderer* e2d::internal::RendererImpl::getRenderer() const
-{
-    return this->m_renderer;
-}
-
-void e2d::internal::RendererImpl::clear(const e2d::Color& drawColor)
-{
-    SDL_SetRenderDrawColor(this->m_renderer, drawColor.r, drawColor.g, drawColor.b, drawColor.a);
-    SDL_RenderClear(this->m_renderer);
-}
-
-void e2d::internal::RendererImpl::display()
-{
-    SDL_RenderPresent(this->m_renderer);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ e2d_add_test(e2d-test-core "${CORE_SRC}" E2D::Core)
 set(ENGINE_SRC
     Engine/Application.test.cpp
     Engine/Renderer.test.cpp
+    Engine/RendererQueue.test.cpp
     Engine/Texture.test.cpp
     Engine/Window.test.cpp
 )

--- a/test/Engine/RendererQueue.test.cpp
+++ b/test/Engine/RendererQueue.test.cpp
@@ -1,0 +1,92 @@
+/**
+ * RendererQueue.test.cpp
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Emil Hörnlund
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <E2D/Engine/Renderable.hpp>
+#include <E2D/Engine/RenderQueue.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+class MyRenderable : public e2d::Renderable
+{
+public:
+    explicit MyRenderable(int renderPriority) : m_renderPriority(renderPriority)
+    {
+    }
+
+    int getRenderPriority() const final
+    {
+        return m_renderPriority;
+    }
+
+    void render(const e2d::Renderer& renderer) const final
+    {
+        (void)renderer; // Explicitly mark as unused
+    }
+
+private:
+    int m_renderPriority;
+};
+
+TEST_CASE("RenderQueue Functionality", "[RenderQueue]")
+{
+    e2d::internal::RenderQueue renderQueue;
+
+    MyRenderable obj1(10);
+    MyRenderable obj2(20);
+    MyRenderable obj3(5);
+
+    SECTION("Queue starts empty")
+    {
+        REQUIRE(renderQueue.isEmpty() == true);
+    }
+
+    SECTION("Objects are ordered by render priority")
+    {
+        renderQueue.push(&obj1);
+        renderQueue.push(&obj2);
+        renderQueue.push(&obj3);
+
+        // The order should be obj3, obj1, obj2 based on render priority
+        REQUIRE(renderQueue.pop()->getRenderPriority() == 5);  //obj3
+        REQUIRE(renderQueue.pop()->getRenderPriority() == 10); //obj1
+        REQUIRE(renderQueue.pop()->getRenderPriority() == 20); //obj2
+    }
+
+    SECTION("Pop from an empty queue returns nullptr")
+    {
+        REQUIRE(renderQueue.pop() == nullptr);
+    }
+
+    SECTION("Queue is empty after popping all elements")
+    {
+        renderQueue.push(&obj1);
+        renderQueue.push(&obj2);
+        renderQueue.pop(); // Pop obj2
+        renderQueue.pop(); // Pop obj1
+
+        REQUIRE(renderQueue.isEmpty() == true);
+    }
+}


### PR DESCRIPTION
This commit introduces significant changes and improvements to the rendering system of the E2D engine. Key highlights include:

1. Creation of the `Renderable` interface: An abstract base class defining a standard interface for all renderable objects. This class includes pure virtual methods `getRenderPriority` and `render`, which must be implemented by all derived classes.

2. Enhancement of the `Renderer` class: Updates have been made to handle the rendering process more effectively. It now supports the management and execution of rendering operations for `Renderable` objects and includes a render queue to prioritize these objects.

3. Introduction of `Sprite` class: A new concrete implementation of the `Renderable` interface, representing 2D graphical objects with associated textures and rendering priorities.

4. Addition of `RenderQueue`: A new utility class for managing a priority queue of `Renderable` objects, ensuring they are rendered in the correct order based on their render priorities.

5. Refactoring and cleanup: The `Application` class has been refactored to remove the redundant `render` method, and CMakeLists have been updated to accommodate new files and changes.

This set of changes greatly enhances the flexibility and capability of the E2D engine's rendering system, laying the groundwork for more complex rendering features in the future.