### PR TITLE
Add Rect class to E2D Core module

### DIFF
--- a/include/E2D/Core.hpp
+++ b/include/E2D/Core.hpp
@@ -31,6 +31,7 @@
 
 #include <E2D/Core/Color.hpp>
 #include <E2D/Core/NonCopyable.hpp>
+#include <E2D/Core/Rect.hpp>
 #include <E2D/Core/Timer.hpp>
 #include <E2D/Core/Vector2.hpp>
 

--- a/include/E2D/Core/Rect.hpp
+++ b/include/E2D/Core/Rect.hpp
@@ -1,0 +1,142 @@
+/**
+* Rect.hpp
+*
+* MIT License
+*
+* Copyright (c) 2023 Emil Hörnlund
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <E2D/Core/Vector2.hpp>
+
+#include <optional>
+
+/**
+ * @brief Namespace for E2D
+ */
+namespace e2d
+{
+
+/**
+ * @class e2d::Rect
+ * @brief Represents a rectangle defined by a position (top-left corner) and a size (width and height).
+ *
+ * @tparam T The numerical type of the rectangle's components (e.g., int, float, double).
+ */
+template <typename T>
+class Rect
+{
+public:
+    /**
+     * @brief Constructs a default rectangle with zeroed position and size.
+     */
+    constexpr Rect();
+
+    /**
+     * @brief Constructs a rectangle with specified position and size.
+     *
+     * @param position The position of the top-left corner of the rectangle.
+     * @param size The size of the rectangle.
+     */
+    constexpr Rect(const Vector2<T>& position, const Vector2<T>& size);
+
+    /**
+     * @brief Constructs a rectangle by converting from another rectangle of a different type.
+     *
+     * @tparam U The type of the source rectangle.
+     * @param rectangle The rectangle to convert from.
+     */
+    template <typename U>
+    constexpr explicit Rect(const Rect<U>& rectangle);
+
+    /**
+     * @brief Checks if the rectangle contains a given point.
+     *
+     * @param point The point to check.
+     * @return true if the rectangle contains the point, false otherwise.
+     */
+    constexpr bool contains(const Vector2<T>& point) const;
+
+    /**
+     * @brief Finds the intersection with another rectangle.
+     *
+     * @param rectangle The other rectangle to find the intersection with.
+     * @return An optional containing the intersection rectangle if it exists, std::nullopt otherwise.
+     */
+    constexpr std::optional<Rect<T>> findIntersection(const Rect<T>& rectangle) const;
+
+    /**
+     * @brief Gets the position of the rectangle.
+     *
+     * @return The position of the top-left corner of the rectangle.
+     */
+    constexpr Vector2<T> getPosition() const;
+
+    /**
+     * @brief Gets the size of the rectangle.
+     *
+     * @return The size of the rectangle.
+     */
+    constexpr Vector2<T> getSize() const;
+
+    /**
+     * @brief Gets the center point of the rectangle.
+     *
+     * @return The center point of the rectangle.
+     */
+    constexpr Vector2<T> getCenter() const;
+
+    T left{};   //!< The left coordinate of the rectangle.
+    T top{};    //!< The top coordinate of the rectangle.
+    T width{};  //!< The width of the rectangle.
+    T height{}; //!< The height of the rectangle.
+};
+
+using IntRect    = Rect<int>;    //!< Specialization of Rect for int type.
+using FloatRect  = Rect<float>;  //!< Specialization of Rect for float type.
+using DoubleRect = Rect<double>; //!< Specialization of Rect for double type.
+
+/**
+ * @brief Compares two rectangles for equality.
+ *
+ * @tparam T The numerical type of the rectangle's components.
+ * @param left The first rectangle.
+ * @param right The second rectangle.
+ * @return true if the rectangles are equal, false otherwise.
+ */
+template <typename T>
+[[nodiscard]] constexpr bool operator==(const Rect<T>& left, const Rect<T>& right);
+
+/**
+ * @brief Compares two rectangles for inequality.
+ *
+ * @tparam T The numerical type of the rectangle's components.
+ * @param left The first rectangle.
+ * @param right The second rectangle.
+ * @return true if the rectangles are not equal, false otherwise.
+ */
+template <typename T>
+[[nodiscard]] constexpr bool operator!=(const Rect<T>& left, const Rect<T>& right);
+
+#include <E2D/Core/Rect.inl>
+
+} // namespace e2d

--- a/include/E2D/Core/Rect.inl
+++ b/include/E2D/Core/Rect.inl
@@ -1,0 +1,123 @@
+/**
+* Rect.inl
+*
+* MIT License
+*
+* Copyright (c) 2023 Emil Hörnlund
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+template <typename T>
+constexpr Rect<T>::Rect() = default;
+
+template <typename T>
+constexpr Rect<T>::Rect(const Vector2<T>& position, const Vector2<T>& size) :
+left(position.x),
+top(position.y),
+width(size.x),
+height(size.y)
+{
+}
+
+template <typename T>
+template <typename U>
+constexpr Rect<T>::Rect(const Rect<U>& rectangle) :
+left(static_cast<T>(rectangle.left)),
+top(static_cast<T>(rectangle.top)),
+width(static_cast<T>(rectangle.width)),
+height(static_cast<T>(rectangle.height))
+{
+}
+
+template <typename T>
+constexpr bool Rect<T>::contains(const Vector2<T>& point) const
+{
+    const auto min = [](T a, T b) { return (a < b) ? a : b; };
+    const auto max = [](T a, T b) { return (a < b) ? b : a; };
+
+    const T minX = min(left, static_cast<T>(left + width));
+    const T maxX = max(left, static_cast<T>(left + width));
+    const T minY = min(top, static_cast<T>(top + height));
+    const T maxY = max(top, static_cast<T>(top + height));
+
+    return (point.x >= minX) && (point.x < maxX) && (point.y >= minY) && (point.y < maxY);
+}
+
+template <typename T>
+constexpr std::optional<Rect<T>> Rect<T>::findIntersection(const Rect<T>& rectangle) const
+{
+    const auto min = [](T a, T b) { return (a < b) ? a : b; };
+    const auto max = [](T a, T b) { return (a < b) ? b : a; };
+
+    const T r1MinX = min(left, static_cast<T>(left + width));
+    const T r1MaxX = max(left, static_cast<T>(left + width));
+    const T r1MinY = min(top, static_cast<T>(top + height));
+    const T r1MaxY = max(top, static_cast<T>(top + height));
+
+    const T r2MinX = min(rectangle.left, static_cast<T>(rectangle.left + rectangle.width));
+    const T r2MaxX = max(rectangle.left, static_cast<T>(rectangle.left + rectangle.width));
+    const T r2MinY = min(rectangle.top, static_cast<T>(rectangle.top + rectangle.height));
+    const T r2MaxY = max(rectangle.top, static_cast<T>(rectangle.top + rectangle.height));
+
+    const T interLeft   = max(r1MinX, r2MinX);
+    const T interTop    = max(r1MinY, r2MinY);
+    const T interRight  = min(r1MaxX, r2MaxX);
+    const T interBottom = min(r1MaxY, r2MaxY);
+
+    if ((interLeft < interRight) && (interTop < interBottom))
+    {
+        return Rect<T>({interLeft, interTop}, {interRight - interLeft, interBottom - interTop});
+    }
+    else
+    {
+        return std::nullopt;
+    }
+}
+
+template <typename T>
+constexpr Vector2<T> Rect<T>::getPosition() const
+{
+    return Vector2<T>(left, top);
+}
+
+template <typename T>
+constexpr Vector2<T> Rect<T>::getSize() const
+{
+    return Vector2<T>(width, height);
+}
+
+template <typename T>
+constexpr Vector2<T> Rect<T>::getCenter() const
+{
+    return getPosition() + getSize() / T{2};
+}
+
+template <typename T>
+constexpr bool operator==(const Rect<T>& left, const Rect<T>& right)
+{
+    return (left.left == right.left) && (left.width == right.width) && (left.top == right.top) &&
+           (left.height == right.height);
+}
+
+template <typename T>
+constexpr bool operator!=(const Rect<T>& left, const Rect<T>& right)
+{
+    return !(left == right);
+}

--- a/src/E2D/Core/CMakeLists.txt
+++ b/src/E2D/Core/CMakeLists.txt
@@ -8,6 +8,8 @@ set(SRC
     ${INCROOT}/Color.inl
     ${INCROOT}/Export.hpp
     ${INCROOT}/NonCopyable.hpp
+    ${INCROOT}/Rect.hpp
+    ${INCROOT}/Rect.inl
     ${INCROOT}/Timer.hpp
     ${SRCROOT}/Timer.cpp
     ${INCROOT}/Vector2.hpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ target_include_directories(Catch2 SYSTEM INTERFACE ${CATCH2_INCLUDE_DIRS})
 # E2D Core Library Tests
 set(CORE_SRC
     Core/Color.test.cpp
+    Core/Rect.test.cpp
     Core/Timer.test.cpp
     Core/Vector2.test.cpp
 )

--- a/test/Core/Rect.test.cpp
+++ b/test/Core/Rect.test.cpp
@@ -1,0 +1,177 @@
+/**
+* Rect.test.cpp
+*
+* MIT License
+*
+* Copyright (c) 2023 Emil Hörnlund
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+#include <E2D/Core/Rect.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("Rect Tests", "[Rect]")
+{
+    SECTION("Default Constructor")
+    {
+        const e2d::Rect<float> rect;
+        REQUIRE(rect.left == 0.0f);
+        REQUIRE(rect.top == 0.0f);
+        REQUIRE(rect.width == 0.0f);
+        REQUIRE(rect.height == 0.0f);
+    }
+
+    SECTION("Constructor with Negative Width and Height")
+    {
+        const e2d::Rect<int> rect({10, 20}, {-30, -40});
+        REQUIRE(rect.left == 10);
+        REQUIRE(rect.top == 20);
+        REQUIRE(rect.width == -30);
+        REQUIRE(rect.height == -40);
+    }
+
+    SECTION("Parameterized Constructor")
+    {
+        const e2d::Rect<int> rect(e2d::Vector2i{10, 20}, e2d::Vector2i{30, 40});
+        REQUIRE(rect.left == 10);
+        REQUIRE(rect.top == 20);
+        REQUIRE(rect.width == 30);
+        REQUIRE(rect.height == 40);
+    }
+
+    SECTION("Copy Constructor with Different Type")
+    {
+        const e2d::Rect<int>   intRect({1, 2}, {3, 4});
+        const e2d::Rect<float> floatRect(intRect);
+        REQUIRE(floatRect.left == 1.0f);
+        REQUIRE(floatRect.top == 2.0f);
+        REQUIRE(floatRect.width == 3.0f);
+        REQUIRE(floatRect.height == 4.0f);
+    }
+
+    SECTION("Contains Method - Point Inside")
+    {
+        const e2d::Rect<int> rect({0, 0}, {10, 10});
+        REQUIRE(rect.contains(e2d::Vector2i{5, 5}));
+        REQUIRE_FALSE(rect.contains(e2d::Vector2i{-1, -1}));
+    }
+
+    SECTION("Contains Method - Point Outside")
+    {
+        const e2d::Rect<int> rect({0, 0}, {10, 10});
+        REQUIRE_FALSE(rect.contains(e2d::Vector2i{11, 11}));
+        REQUIRE_FALSE(rect.contains(e2d::Vector2i{0, 11}));
+        REQUIRE_FALSE(rect.contains(e2d::Vector2i{-1, 5}));
+    }
+
+    SECTION("Contains Method - Point On Boundary")
+    {
+        const e2d::Rect<int> rect({0, 0}, {10, 10});
+        REQUIRE_FALSE(rect.contains(e2d::Vector2i{10, 10}));
+        REQUIRE(rect.contains(e2d::Vector2i{0, 0}));
+    }
+
+    SECTION("Find Intersection Method")
+    {
+        const e2d::Rect<int> rect1({0, 0}, {10, 10});
+        const e2d::Rect<int> rect2({5, 5}, {10, 10});
+        auto                 intersection = rect1.findIntersection(rect2);
+        REQUIRE(intersection.has_value());
+        REQUIRE(intersection->left == 5);
+        REQUIRE(intersection->top == 5);
+        REQUIRE(intersection->width == 5);
+        REQUIRE(intersection->height == 5);
+    }
+
+    SECTION("Find Intersection Method - No Intersection (Completely Separate)")
+    {
+        const e2d::Rect<int> rect1({0, 0}, {10, 10});
+        const e2d::Rect<int> rect2({20, 20}, {10, 10});
+        auto                 intersection = rect1.findIntersection(rect2);
+        REQUIRE_FALSE(intersection.has_value());
+    }
+
+    SECTION("Find Intersection Method - Edge Touching")
+    {
+        const e2d::Rect<int> rect1({0, 0}, {10, 10});
+        const e2d::Rect<int> rect2({10, 0}, {10, 10});
+        auto                 intersection = rect1.findIntersection(rect2);
+        REQUIRE_FALSE(intersection.has_value());
+    }
+
+    SECTION("Find Intersection Method - One Inside Another")
+    {
+        const e2d::Rect<int> rect1({0, 0}, {10, 10});
+        const e2d::Rect<int> rect2({2, 2}, {5, 5});
+        auto                 intersection = rect1.findIntersection(rect2);
+        REQUIRE(intersection.has_value());
+        REQUIRE(intersection->left == 2);
+        REQUIRE(intersection->top == 2);
+        REQUIRE(intersection->width == 5);
+        REQUIRE(intersection->height == 5);
+    }
+
+    SECTION("GetPosition Method")
+    {
+        const e2d::Rect<int> rect({10, 20}, {30, 40});
+        auto                 position = rect.getPosition();
+        REQUIRE(position.x == 10);
+        REQUIRE(position.y == 20);
+    }
+
+    SECTION("GetSize Method")
+    {
+        const e2d::Rect<int> rect({10, 20}, {30, 40});
+        auto                 size = rect.getSize();
+        REQUIRE(size.x == 30);
+        REQUIRE(size.y == 40);
+    }
+
+    SECTION("GetCenter Method")
+    {
+        const e2d::Rect<int> rect({10, 20}, {30, 40});
+        auto                 center = rect.getCenter();
+        REQUIRE(center.x == 25);
+        REQUIRE(center.y == 40);
+    }
+
+    SECTION("GetCenter Method - Negative Dimensions")
+    {
+        const e2d::Rect<int> rect({10, 20}, {-30, -40});
+        const e2d::Vector2i  center = rect.getCenter();
+        REQUIRE(center.x == -5);
+        REQUIRE(center.y == 0);
+    }
+
+    SECTION("Equality Operator")
+    {
+        const e2d::Rect<int> rect1({10, 20}, {30, 40});
+        const e2d::Rect<int> rect2({10, 20}, {30, 40});
+        REQUIRE(rect1 == rect2);
+    }
+
+    SECTION("Inequality Operator")
+    {
+        const e2d::Rect<int> rect1({10, 20}, {30, 40});
+        const e2d::Rect<int> rect2({20, 30}, {40, 50});
+        REQUIRE(rect1 != rect2);
+    }
+}


### PR DESCRIPTION
- Introduce the new Rect class template in the E2D Core module. This class represents a rectangle defined by a position and size, with template support for different numerical types (e.g., int, float, double).
- Implement basic functionalities including constructors for default values, parameterized values, and type conversion, along with utility functions like contains, findIntersection, getPosition, getSize, and getCenter.
- Include equality and inequality comparison operators for Rect objects.
- Add the Rect class header and implementation files (Rect.hpp and Rect.inl) to the E2D Core CMakeLists.
- Create unit tests for the Rect class, covering various scenarios including default construction, parameterized construction, boundary conditions, intersection checking, and operator tests.