### PR TITLE
Add getSize method to Texture and fix ObjectRegistry documentation

### DIFF
--- a/include/E2D/Engine/ObjectRegistry.hpp
+++ b/include/E2D/Engine/ObjectRegistry.hpp
@@ -37,12 +37,7 @@
 #include <vector>
 
 /**
- * @class ObjectRegistry
- * @brief Manages a registry of all game objects in the E2D Engine.
- *
- * ObjectRegistry is responsible for managing the lifecycle of all game objects. It provides
- * methods to add, retrieve, and remove objects from the game. The registry can also return
- * all objects or objects of a specific type.
+ * @brief Namespace for E2D
  */
 namespace e2d
 {
@@ -50,7 +45,11 @@ class Object; // Forward declaration of Object
 
 /**
  * @class ObjectRegistry
- * @brief
+ * @brief Manages a registry of all game objects in the E2D Engine.
+ *
+ * ObjectRegistry is responsible for managing the lifecycle of all game objects. It provides
+ * methods to add, retrieve, and remove objects from the game. The registry can also return
+ * all objects or objects of a specific type.
  */
 class E2D_ENGINE_API ObjectRegistry final : NonCopyable
 {

--- a/include/E2D/Engine/Texture.hpp
+++ b/include/E2D/Engine/Texture.hpp
@@ -30,6 +30,7 @@
 #include <E2D/Engine/Export.hpp>
 
 #include <E2D/Core/NonCopyable.hpp>
+#include <E2D/Core/Vector2.hpp>
 
 #include <memory>
 #include <string>
@@ -90,6 +91,17 @@ public:
      * @brief Destroys the texture, freeing associated resources.
      */
     void destroy();
+
+    /**
+     * @brief Retrieves the size of the texture.
+     *
+     * This method returns the dimensions of the texture as a Vector2i,
+     * where x represents the width and y represents the height of the texture.
+     * If the texture is not loaded, this method returns a vector with zero values.
+     *
+     * @return const Vector2i& Reference to a Vector2i object representing the texture's size.
+     */
+    const Vector2i& getSize() const;
 
     /**
      * @brief Retrieves a handle to the native texture object.

--- a/src/E2D/Engine/Texture.cpp
+++ b/src/E2D/Engine/Texture.cpp
@@ -51,6 +51,11 @@ void e2d::Texture::destroy()
     this->m_textureImpl->destroy();
 }
 
+const e2d::Vector2i& e2d::Texture::getSize() const
+{
+    return this->m_textureImpl->getSize();
+}
+
 void* e2d::Texture::getNativeTextureHandle() const
 {
     return this->m_textureImpl->getTexture();

--- a/src/E2D/Engine/TextureImpl.cpp
+++ b/src/E2D/Engine/TextureImpl.cpp
@@ -50,6 +50,12 @@ bool e2d::internal::TextureImpl::loadTexture(SDL_Renderer* renderer, const char*
         std::cerr << "Failed to load texture: " << SDL_GetError() << '\n';
         return false;
     }
+    if (SDL_QueryTexture(this->m_texture, nullptr, nullptr, &this->m_textureSize.x, &this->m_textureSize.y) != 0)
+    {
+        std::cerr << "Failed to query texture: " << SDL_GetError() << '\n';
+        this->destroy();
+        return false;
+    }
     return true;
 }
 
@@ -63,8 +69,14 @@ void e2d::internal::TextureImpl::destroy()
     if (this->m_texture)
     {
         SDL_DestroyTexture(this->m_texture);
-        this->m_texture = nullptr;
+        this->m_texture     = nullptr;
+        this->m_textureSize = {0, 0};
     }
+}
+
+const e2d::Vector2i& e2d::internal::TextureImpl::getSize() const
+{
+    return this->m_textureSize;
 }
 
 SDL_Texture* e2d::internal::TextureImpl::getTexture() const

--- a/src/E2D/Engine/TextureImpl.hpp
+++ b/src/E2D/Engine/TextureImpl.hpp
@@ -30,6 +30,7 @@
 #include <E2D/Engine/Export.hpp>
 
 #include <E2D/Core/NonCopyable.hpp>
+#include <E2D/Core/Vector2.hpp>
 
 struct SDL_Renderer; // Forward declaration of SDL_Renderer
 struct SDL_Texture;  // Forward declaration of SDL_Texture
@@ -86,6 +87,18 @@ public:
     void destroy();
 
     /**
+     * @brief Retrieves the size of the internal SDL texture.
+     *
+     * This method returns the dimensions of the underlying SDL texture.
+     * It queries the texture's width and height, storing them in a Vector2i.
+     * If the texture is not loaded or the query fails, the method returns
+     * a vector with zero values.
+     *
+     * @return const e2d::Vector2i& Reference to a Vector2i object representing the texture's size.
+     */
+    const e2d::Vector2i& getSize() const;
+
+    /**
      * @brief Retrieves the native SDL texture object.
      *
      * @return Pointer to the underlying SDL_Texture object.
@@ -93,7 +106,8 @@ public:
     SDL_Texture* getTexture() const;
 
 private:
-    SDL_Texture* m_texture{nullptr}; //!< Pointer to the SDL_Texture object.
+    SDL_Texture*  m_texture{nullptr}; //!< Pointer to the SDL_Texture object.
+    e2d::Vector2i m_textureSize;      //!< Stores the dimensions of the SDL_Texture object.
 
 }; // class TextureImpl
 

--- a/test/Engine/Texture.test.cpp
+++ b/test/Engine/Texture.test.cpp
@@ -61,8 +61,12 @@ TEST_CASE_METHOD(TextureTest, "Texture Loading and Destruction", "[Texture]")
 
     SECTION("Load Texture")
     {
+        REQUIRE(texture.getSize() == e2d::Vector2i{0, 0});
+
         REQUIRE(texture.loadTexture(renderer, "resources/hello-world.png") == true);
         REQUIRE(texture.isLoaded() == true);
+
+        REQUIRE(texture.getSize() == e2d::Vector2i{320, 240});
     }
 
     SECTION("Destroy Texture")
@@ -70,5 +74,7 @@ TEST_CASE_METHOD(TextureTest, "Texture Loading and Destruction", "[Texture]")
         REQUIRE(texture.loadTexture(renderer, "resources/hello-world.png") == true);
         texture.destroy();
         REQUIRE(texture.isLoaded() == false);
+
+        REQUIRE(texture.getSize() == e2d::Vector2i{0, 0});
     }
 }


### PR DESCRIPTION
- Implemented a new getSize method in the Texture class to return the size of the texture as a Vector2i object. This method provides the dimensions (width and height) of the texture, enhancing the Texture class's functionality.
- Added complete Doxygen documentation for the getSize method in both Texture and TextureImpl classes. This documentation clearly explains the method's purpose, return type, and behavior when the texture is not loaded.
- Corrected the placement of the ObjectRegistry class documentation in ObjectRegistry.hpp. The detailed class description was mistakenly placed under the namespace documentation and is now correctly associated with the ObjectRegistry class itself.
- Updated Texture unit tests to cover the new getSize method. These tests validate the method's functionality by checking texture sizes before and after loading a texture, as well as after destroying it.

This commit enhances the Texture class's capabilities and ensures proper documentation standards are maintained in the ObjectRegistry class.