### PR TITLE
Expand event handling in E2D engine for window and mouse events

### DIFF
--- a/include/E2D/Engine/Event.hpp
+++ b/include/E2D/Engine/Event.hpp
@@ -75,16 +75,24 @@ struct Event
      * @enum EventType
      * @brief Enumerates the types of events that can be processed by the E2D engine.
      *
-     * This enum defines the various event types that the E2D engine can process, including
-     * keyboard inputs, window events, and system commands like quitting the application.
+     * This enum defines the various event types that the E2D engine can handle. It includes
+     * system events like window closing, resizing, focus changes, and key events.
      */
     enum EventType
     {
-        Unknown,     //!< Represents an unknown event.
-        KeyPressed,  //!< Represents a key press event.
-        KeyReleased, //!< Represents a key release event.
-        Resized,     //!< Represents a window resize event.
-        Quit,        //!< Represents a quit event, typically triggered by closing the application window.
+        Unknown,      //!< Represents an unknown event.
+        Closed,       //!< Represents a window close event.
+        Resized,      //!< Represents a window resize event.
+        LostFocus,    //!< Represents an event where the window loses focus.
+        GainedFocus,  //!< Represents an event where the window gains focus.
+        Minimized,    //!< Represents an event where the window is minimized.
+        Maximized,    //!< Represents an event where the window is maximized.
+        Restored,     //!< Represents an event where the window is restored from minimized or maximized state.
+        KeyPressed,   //!< Represents a key press event.
+        KeyReleased,  //!< Represents a key release event.
+        MouseEntered, //!< Represents an event where the mouse enters the window boundaries.
+        MouseLeft,    //!< Represents an event where the mouse leaves the window boundaries.
+        Quit,         //!< Represents a quit event, typically triggered by closing the application window.
     };
 
     EventType type{}; //!< Type of the event, indicating what kind of event occurred.

--- a/src/E2D/Engine/Application.cpp
+++ b/src/E2D/Engine/Application.cpp
@@ -80,7 +80,7 @@ int e2d::Application::run()
         e2d::Event event{};
         while (pollEvent(event))
         {
-            if (event.type == Event::Quit)
+            if (event.type == Event::Closed)
             {
                 this->quit();
             }

--- a/src/E2D/Engine/Event.cpp
+++ b/src/E2D/Engine/Event.cpp
@@ -109,10 +109,34 @@ bool toWindowEvent(const SDL_Event& sdlEvent, e2d::Event& event)
     {
         switch (sdlEvent.window.event)
         {
+            case SDL_WINDOWEVENT_CLOSE:
+                event.type = e2d::Event::Closed;
+                return true;
             case SDL_WINDOWEVENT_SIZE_CHANGED:
                 event.type        = e2d::Event::Resized;
                 event.size.width  = static_cast<unsigned int>(sdlEvent.window.data1);
                 event.size.height = static_cast<unsigned int>(sdlEvent.window.data2);
+                return true;
+            case SDL_WINDOWEVENT_FOCUS_LOST:
+                event.type = e2d::Event::LostFocus;
+                return true;
+            case SDL_WINDOWEVENT_FOCUS_GAINED:
+                event.type = e2d::Event::GainedFocus;
+                return true;
+            case SDL_WINDOWEVENT_MINIMIZED:
+                event.type = e2d::Event::Minimized;
+                return true;
+            case SDL_WINDOWEVENT_MAXIMIZED:
+                event.type = e2d::Event::Maximized;
+                return true;
+            case SDL_WINDOWEVENT_RESTORED:
+                event.type = e2d::Event::Restored;
+                return true;
+            case SDL_WINDOWEVENT_ENTER:
+                event.type = e2d::Event::MouseEntered;
+                return true;
+            case SDL_WINDOWEVENT_LEAVE:
+                event.type = e2d::Event::MouseLeft;
                 return true;
             default:
                 break;

--- a/test/Engine/Event.test.cpp
+++ b/test/Engine/Event.test.cpp
@@ -137,6 +137,20 @@ TEST_CASE_METHOD(EventTest, "pollEvent", "[Event]")
         REQUIRE(actualEvent.key.system == true);
     }
 
+    SECTION("Handle Window Close Event")
+    {
+        sdlEvent.type         = SDL_WINDOWEVENT;
+        sdlEvent.window.event = SDL_WINDOWEVENT_CLOSE;
+
+        SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
+        SDL_PushEvent(&sdlEvent);
+
+        wasPolled = e2d::pollEvent(actualEvent);
+
+        REQUIRE(wasPolled == true);
+        REQUIRE(actualEvent.type == e2d::Event::Closed);
+    }
+
     SECTION("Handle Window Resize Event")
     {
         sdlEvent.type         = SDL_WINDOWEVENT;
@@ -151,6 +165,106 @@ TEST_CASE_METHOD(EventTest, "pollEvent", "[Event]")
 
         REQUIRE(wasPolled == true);
         REQUIRE(actualEvent.type == e2d::Event::Resized);
+        REQUIRE(actualEvent.size.width == 800);
+        REQUIRE(actualEvent.size.height == 600);
+    }
+
+    SECTION("Handle Window Focus Lost Event")
+    {
+        sdlEvent.type         = SDL_WINDOWEVENT;
+        sdlEvent.window.event = SDL_WINDOWEVENT_FOCUS_LOST;
+
+        SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
+        SDL_PushEvent(&sdlEvent);
+
+        wasPolled = e2d::pollEvent(actualEvent);
+
+        REQUIRE(wasPolled == true);
+        REQUIRE(actualEvent.type == e2d::Event::LostFocus);
+    }
+
+    SECTION("Handle Window Focus Gained Event")
+    {
+        sdlEvent.type         = SDL_WINDOWEVENT;
+        sdlEvent.window.event = SDL_WINDOWEVENT_FOCUS_GAINED;
+
+        SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
+        SDL_PushEvent(&sdlEvent);
+
+        wasPolled = e2d::pollEvent(actualEvent);
+
+        REQUIRE(wasPolled == true);
+        REQUIRE(actualEvent.type == e2d::Event::GainedFocus);
+    }
+
+    SECTION("Handle Window Minimized Event")
+    {
+        sdlEvent.type         = SDL_WINDOWEVENT;
+        sdlEvent.window.event = SDL_WINDOWEVENT_MINIMIZED;
+
+        SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
+        SDL_PushEvent(&sdlEvent);
+
+        wasPolled = e2d::pollEvent(actualEvent);
+
+        REQUIRE(wasPolled == true);
+        REQUIRE(actualEvent.type == e2d::Event::Minimized);
+    }
+
+    SECTION("Handle Window Maximized Event")
+    {
+        sdlEvent.type         = SDL_WINDOWEVENT;
+        sdlEvent.window.event = SDL_WINDOWEVENT_MAXIMIZED;
+
+        SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
+        SDL_PushEvent(&sdlEvent);
+
+        wasPolled = e2d::pollEvent(actualEvent);
+
+        REQUIRE(wasPolled == true);
+        REQUIRE(actualEvent.type == e2d::Event::Maximized);
+    }
+
+    SECTION("Handle Window Restored Event")
+    {
+        sdlEvent.type         = SDL_WINDOWEVENT;
+        sdlEvent.window.event = SDL_WINDOWEVENT_RESTORED;
+
+        SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
+        SDL_PushEvent(&sdlEvent);
+
+        wasPolled = e2d::pollEvent(actualEvent);
+
+        REQUIRE(wasPolled == true);
+        REQUIRE(actualEvent.type == e2d::Event::Restored);
+    }
+
+    SECTION("Handle Window Mouse Entered Event")
+    {
+        sdlEvent.type         = SDL_WINDOWEVENT;
+        sdlEvent.window.event = SDL_WINDOWEVENT_ENTER;
+
+        SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
+        SDL_PushEvent(&sdlEvent);
+
+        wasPolled = e2d::pollEvent(actualEvent);
+
+        REQUIRE(wasPolled == true);
+        REQUIRE(actualEvent.type == e2d::Event::MouseEntered);
+    }
+
+    SECTION("Handle Window Mouse Left Event")
+    {
+        sdlEvent.type         = SDL_WINDOWEVENT;
+        sdlEvent.window.event = SDL_WINDOWEVENT_LEAVE;
+
+        SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
+        SDL_PushEvent(&sdlEvent);
+
+        wasPolled = e2d::pollEvent(actualEvent);
+
+        REQUIRE(wasPolled == true);
+        REQUIRE(actualEvent.type == e2d::Event::MouseLeft);
     }
 
     SECTION("Handle Quit Event")


### PR DESCRIPTION
- Updated EventType enum in Event.hpp to include a wider range of window and mouse events such as Closed, LostFocus, GainedFocus, Minimized, Maximized, Restored, MouseEntered, and MouseLeft.
- Revised EventType enum documentation to reflect new event types, emphasizing system events like window state changes and mouse interactions.
- Modified Application.cpp to use the Closed event type for triggering application quit.
- Enhanced toWindowEvent function in Event.cpp to handle new SDL window events, translating them into corresponding E2D events.
- Added comprehensive tests in Event.test.cpp for each new event type, ensuring proper handling and integration into the E2D event system.